### PR TITLE
Fixed Unity Portal application not rendering in the browser viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.0] (Unreleased)
+## [0.9.1] (Unreleased)
 - Changed Docker image build workflow is triggered when a tag is created and no longer triggered when code is merged to `main` or `features/*` branches [#51](https://github.com/unity-sds/unity-ui/issues/51)
 - Changed Docker image build workflow so that it uses the image name `unity-portal-application` instead of `unity-ui-application`
 - Rebranded the application's project references so that they state "MDPS" instead of "Unity" [#55](https://github.com/unity-sds/unity-portal/issues/55)
 - Rebranded the application and repo so that the "ui" is now known as the "portal" [#61](https://github.com/unity-sds/unity-portal/issues/61), [#64](https://github.com/unity-sds/unity-portal/issues/64)
 - Removed hard-coded links for all project's venues [#58](https://github.com/unity-sds/unity-portal/issues/58)
+- Fixed issue with basepath not set correctly after proxy label was updated from `ui` to `portal` [#68](https://github.com/unity-sds/unity-portal/issues/68)
 
 ## [0.8.0] 2025-01-14
 - Added support to report on when health API endpoint is not available in navbar and on health dashboard

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,7 @@ import './index.css'
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <HelmetProvider>
-      <BrowserRouter basename={`${Config['general']['project']}/${Config['general']['venue']}/ui`}>
+      <BrowserRouter basename={`${Config['general']['basePath']}`}>
         <Routes>
           <Route path="*" Component={AuthorizationWrapper}/>
         </Routes>


### PR DESCRIPTION
## Purpose

This PR addresses the fix for the portal application not rendering correctly.

## Proposed Changes
- [FIX] Updated the `basename` value for React Router to coincide with the updated proxy name for the portal that was updated in a previous commit.

## Issues
Fixes #68 

## Testing
- Tested locally and verified fix works via installs using MC in Unity-Venue-Dev