### PR TITLE
Updated consumption of Health API to accommodate new fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rebranded the application and repo so that the "ui" is now known as the "portal" [#61](https://github.com/unity-sds/unity-portal/issues/61), [#64](https://github.com/unity-sds/unity-portal/issues/64)
 - Removed hard-coded links for all project's venues [#58](https://github.com/unity-sds/unity-portal/issues/58)
 - Fixed issue with basepath not set correctly after proxy label was updated from `ui` to `portal` [#68](https://github.com/unity-sds/unity-portal/issues/68)
+- Changed consumption of Health API endpoint so that it now captures information for three new fields, `componentCategory`, `componentType`, and `description` [#71](https://github.com/unity-sds/unity-portal/issues/71)
+- Updated home page view so that it only lists items that have a `componentType` of `ui` [#71](https://github.com/unity-sds/unity-portal/issues/71)
 
 ## [0.8.0] 2025-01-14
 - Added support to report on when health API endpoint is not available in navbar and on health dashboard

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -33,7 +33,7 @@ export const Card = ({
             <Link to={url} target={"_blank"} onClick={ (e) => {onClickExternalHandler(e)}}><IconExternalLink /></Link>
           </span>
         </span>
-        <div className="description">{description}</div>
+       { description && <div className="description">{description}</div> }
         <div className="footer">
           <Pill label={type}/>
         </div>

--- a/src/routes/health-dashboard/index.tsx
+++ b/src/routes/health-dashboard/index.tsx
@@ -42,6 +42,9 @@ function HealthDashboard() {
   // Each Column Definition results in one Column.
   const [columnDefs] = useState([
     { field: "componentName", headerName: "Service", filter: true },
+    { field: "description", headerName: "Description", filter: true },
+    { field: "componentCategory", headerName: "Category", filter: true },
+    { field: "componentType", headerName: "Type", filter: true },
     {
       cellClass: 'mdps-aggrid-health-status',
       cellRenderer: StatusCellRenderer,
@@ -50,11 +53,13 @@ function HealthDashboard() {
       headerName: "Status",
       valueGetter: "data.healthChecks[0].status",
     },
-    { field: "landingPageUrl", 
+    {
+      field: "landingPageUrl", 
       cellRenderer: LinkCellRenderer,
       headerName: "Landing Page", filter: true, cellStyle: { color: '#0000FF', textDecoration: 'underline' }
     },
-    { field: "healthCheckUrl", 
+    {
+      field: "healthCheckUrl", 
       cellRenderer: LinkCellRenderer,
       headerName: "Health Check Page", filter: true, cellStyle: { color: '#0000FF', textDecoration: 'underline' }
     },

--- a/src/routes/home/index.tsx
+++ b/src/routes/home/index.tsx
@@ -2,21 +2,23 @@ import { Card } from "../../components/Card";
 
 import { DocumentMeta } from "../../components/DocumentMeta/DocumentMeta";
 import { useAppSelector } from "../../state/hooks";
+import { getUiItems } from "../../state/selectors/healthSelectors";
+import { Service } from "../../state/slices/healthSlice";
 import { formatRoute } from "../../utils/strings";
 
 function Home() {
 
-  const healthState = useAppSelector((state) => {
-    return state.health;
+  const uiItems:Service[] = useAppSelector((state) => { 
+    return getUiItems(state.health);
   });
 
-  let appCards = healthState.items.map( (item) => {
+  let appCards = uiItems.map( (item) => {
     return (
       <Card
-        description={"Vivamus consequat, tellus vel faucibus dictum, ante nisi."}
+        description={item.description}
         route={"/applications/" + formatRoute(item.componentName)}
         title={item.componentName}
-        type={"web"}
+        type={item.componentType}
         url={item.landingPageUrl}
       />
     )
@@ -27,14 +29,14 @@ function Home() {
       description={`Check the health status of services running in this venue.`}
       route={"/health-dashboard"}
       title="Health Dashboard"
-      type={"web"}
+      type={"ui"}
       url={"/health-dashboard"}
     />,
     <Card
       description="Documentation to help become familiar with the Unity platform."
       route={"https://unity-sds.gitbook.io/docs"}
       title="Documentation (Gitbook)"
-      type={"web"}
+      type={"ui"}
       url={"https://unity-sds.gitbook.io/docs"}
     />
   );

--- a/src/state/selectors/healthSelectors.ts
+++ b/src/state/selectors/healthSelectors.ts
@@ -1,5 +1,9 @@
-import { HealthState } from "../slices/healthSlice";
+import { HealthState, Service } from "../slices/healthSlice";
 
 export const healthDataRequiresFetchOrUpdate = (state:HealthState):boolean => {
   return state.status === 'failed' || state.lastUpdated === undefined || state.lastUpdated <= (Date.now() - 60000)
 };
+
+export const getUiItems = (state:HealthState):Service[] => {
+  return state.items.filter( (item) => item.componentType.toLowerCase() == "ui" )
+}

--- a/src/state/slices/healthSlice.ts
+++ b/src/state/slices/healthSlice.ts
@@ -15,6 +15,9 @@ type HealthCheck = {
 
 export type Service = {
   componentName:string;
+  componentCategory:string;
+  componentType:string;
+  description:string;
   healthCheckUrl:string;
   landingPageUrl:string;
   healthChecks: Array<HealthCheck>;


### PR DESCRIPTION
## Purpose

This PR addresses the need for updating usage of the Health API so that three new fields can be referenced, `componentCategory`, `componentType`, and `description`

## Proposed Changes
- [CHANGE] Consumption of Health API now accounts for three new fields, `componentCategory`, `componentType`, and `description`
- [CHANGE] Home page view now only lists items that have a `componentType` value of `ui`.
## Issues
- Resolves #71  
## Testing
- Tested locally using mocked results based on Health API endpoint specifications
